### PR TITLE
Introduce a simple tooltip for the price chart and little reading enchancments

### DIFF
--- a/src/components/CENTRAL_HUB.js
+++ b/src/components/CENTRAL_HUB.js
@@ -21,16 +21,7 @@ function CENTRAL_HUB() {
 			});
 	}, []);
 
-	useEffect(() => {
-		axios
-			.get(API_URL)
-			.then((res) => {
-				setCoins(res.data);
-			})
-			.catch((err) => {
-				console.log(err);
-			});
-	}, []);
+	
 
 	return (
 		<div>

--- a/src/components/CHART_TOOLTIP.js
+++ b/src/components/CHART_TOOLTIP.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { timeFormat } from 'd3'
+
+function CHART_TOOLTIP({ prices, xScale, yScale, activeIndex }) {
+
+
+    const formatDate = timeFormat("%m/%d/%Y")
+
+
+    
+    return (
+        prices.map((item, index) => 
+        <g key={index} >
+        <circle
+            cx={xScale(item[0])}
+            cy={yScale(item[1])}
+            r={2}
+            fill='#A0B700'
+            strokeWidth={index === activeIndex ? 2 : 0}
+            stroke="#fff"
+            style={{ transition: "ease-out .1s" }}
+        />
+        <g className='tooltip-box'>
+        <text 
+            className= 'tooltip-info'
+            x={xScale(item[0])}
+            y={30}
+            textAnchor="middle"
+        >
+            {index === activeIndex ? `Price: $${Math.round(item[1] * 100) / 100}` : ""}
+        </text>
+        <text 
+            className= 'tooltip-info'
+            x={xScale(item[0])}
+            y={45}
+            textAnchor="middle"
+        >
+            {index === activeIndex ? ` Date: ${formatDate(item[0])}` : ""}
+        </text>
+        </g>
+    </g>
+    ))
+            
+
+}
+
+
+export default CHART_TOOLTIP

--- a/src/components/COIN.js
+++ b/src/components/COIN.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import '../css/COIN_STYLES.css';
+import { numberWithCommas } from './FORMAT_FUNCTIONS.js'
+
 
 function COIN(props) {
 	const { name, symbol, img, price, high, low, marketcap, id, rank } = props;
+
+	
 
 	return (
 		<div className='Coin-item' data-testid={id}>
@@ -18,10 +22,10 @@ function COIN(props) {
 			<div className='Coin-spec'>
 				<img className='Coin-image' src={img} alt='coin-tag' />{' '}
 			</div>
-			<div className='Coin-spec'>{price}</div>
-			<div className='Coin-spec'>{high}</div>
-			<div className='Coin-spec'>{low}</div>
-			<div className='Coin-spec'>{marketcap}</div>
+			<div className='Coin-spec'>${numberWithCommas(price)}</div>
+			<div className='Coin-spec'>${numberWithCommas(high)}</div>
+			<div className='Coin-spec'>${numberWithCommas(low)}</div>
+			<div className='Coin-spec'>${numberWithCommas(marketcap)}</div>
 		</div>
 	);
 }

--- a/src/components/FORMAT_FUNCTIONS.js
+++ b/src/components/FORMAT_FUNCTIONS.js
@@ -1,0 +1,12 @@
+
+
+export const numberWithCommas = (x) => {
+    let parts = x.toString().split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return parts.join('.');
+};
+
+/*export const stripHtml = (text) => {
+            let doc = new DOMParser().parseFromString(text, 'text/html');
+            return doc.body.textContent || "";
+        }*/

--- a/src/components/PRICE_CHART.js
+++ b/src/components/PRICE_CHART.js
@@ -1,23 +1,27 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { scaleLinear, extent, scaleTime, line, curveNatural } from 'd3';
+import { scaleLinear, extent, scaleTime, line, curveNatural, bisector, pointer } from 'd3';
 import AXIS_BOTTOM from './AXIS_BOTTOM';
 import AXIS_LEFT from './AXIS_LEFT';
+import CHART_TOOLTIP from './CHART_TOOLTIP';
 import '../css/PRICE_CHART_STYLES.css';
 
-function PRICE_CHART({ id, name }) {
-	const svgRef = useRef();
 
+function PRICE_CHART({ id, name }) {
+
+	const [activeIndex, setActiveIndex] = useState([])
 	const [history, setHistory] = useState(null);
-	//const [prices, setPrices] = useState()
-	//const [dates, setDates] = useState()
+	
 
 	const historyURL = `https://api.coingecko.com/api/v3/coins/${id}/market_chart?vs_currency=usd&days=90&interval=daily`;
 
-	//const xValues = []
-	//const yValues = []
+
 	const innerWidth = window.innerWidth * 0.50;
-	const innerHeight = window.innerHeight / 1.7;
+	let innerHeight = window.innerHeight / 1.7;
+	console.log(window.innerHeight)
+
+	if(innerHeight < 500) {innerHeight = 500}
+
 	const margin = {
 		top: 10,
 		left: 50,
@@ -28,7 +32,6 @@ function PRICE_CHART({ id, name }) {
 			.get(historyURL)
 			.then((res) => {
 				setHistory(res.data);
-				console.log(res.data);
 			})
 			.catch((err) => console.log(err));
 	}, [historyURL]);
@@ -37,25 +40,33 @@ function PRICE_CHART({ id, name }) {
 		return <pre>Loading...</pre>;
 	}
 
-				const xValue = (d) => d[0];
-	const yValue = (d) => d[1];
+		const xValue = (d) => d[0];
+		const yValue = (d) => d[1];
 
 		const yScale = scaleLinear()
-	.domain(extent(history.prices, yValue))
-	.range([innerHeight - 70, 30]);
+			.domain(extent(history.prices, yValue))
+			.range([innerHeight - 70, 30]);
 
-	const xScale = scaleTime()
-	.domain(extent(history.prices, xValue))
-	.range([0, innerWidth - 60]);
+		const xScale = scaleTime()
+			.domain(extent(history.prices, xValue))
+			.range([0, innerWidth * 0.9]);
 
-	/*const svg = select(svgRef.current)
-    const xAxis = axisBottom(xScale)
-    svg.select('.x-axis').call(xAxis)*/
+		const handleMouseMove = (e) => {
+			const bisect = bisector(xValue).left,
+			 	x0 = xScale.invert(pointer(e, this)[0]),
+				index = bisect(history.prices, x0, 1);
+			setActiveIndex(index);
+			};
 
+		const handleMouseLeave = () => {
+				setActiveIndex(null);
+			};
+		
+		
 	return (
 		<div className='svg-container'>
-			<svg height={innerHeight} width={innerWidth} ref={svgRef}>
-				<g transform={`translate(${margin.left},${margin.top})`}>
+			<svg height={innerHeight} width={innerWidth} >
+				<g transform={`translate(${margin.left},${margin.top})`} onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave}>
 				<text x='0' y='15' className='chart-title'>{name} to USD Chart</text>
 					<AXIS_BOTTOM xScale={xScale} innerHeight={innerHeight} />
 					<AXIS_LEFT yScale={yScale} innerWidth={innerWidth} />
@@ -65,6 +76,7 @@ function PRICE_CHART({ id, name }) {
 							.y((d) => yScale(yValue(d)))
 							.curve(curveNatural)(history.prices)}
 					/>
+					<CHART_TOOLTIP prices={history.prices} xScale={xScale} yScale={yScale} activeIndex={activeIndex}/>
 				</g>
 			</svg>
 		</div>

--- a/src/components/SINGLE_BAR.js
+++ b/src/components/SINGLE_BAR.js
@@ -1,28 +1,34 @@
 import React from 'react';
 import '../css/SINGLE_BAR_STYLES.css';
+import { numberWithCommas } from './FORMAT_FUNCTIONS.js' 
+import { MdInfoOutline } from 'react-icons/md'
 
 function SINGLE_BAR({ data, symbol }) {
 	symbol = symbol.toUpperCase();
 
 	const remainSupply = (data.circulating_supply * 100) / data.max_supply;
 
-	const numberWithCommas = (x) => {
-		let parts = x.toString().split('.');
-		parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-		return parts.join('.');
-	};
+	
 
 	return (
 		<div className='single-bar-container'>
 			<div className='market-cap-container'>
-				<h6>Market cap:</h6> {data.market_cap.usd}
-				{data.market_cap_change_24h}
+				<h6>Market cap: <span className='info-icon'><MdInfoOutline /></span></h6> 
+				<p>${numberWithCommas(data.market_cap.usd)}</p>
+				<p className={data.market_cap_change_percentage_24h > 0 ?
+								'green-text':
+								'red-text'}>
+					{numberWithCommas(data.market_cap_change_percentage_24h)}%</p>
 			</div>
 			<div className='diluted-container'>
-				<h6>Diluted Market Cap:</h6> {data.market_cap.usd}
+				<h6>Total Volume: <span className='info-icon'><MdInfoOutline /></span></h6> 
+				<p>${data.total_volume.usd ?
+				numberWithCommas(data.total_volume.usd):
+				''}</p>
 			</div>
 			<div className='volume-container'>
-				<h6>Volume 24h:</h6> {data.market_cap.usd}
+				<h6>Volume 24h: <span className='info-icon'><MdInfoOutline /></span></h6> 
+				<p>${numberWithCommas(data.total_volume.usd)}</p>
 			</div>
 			<div className='supply-container'>
 				<h6>Circulating supply</h6>
@@ -33,9 +39,9 @@ function SINGLE_BAR({ data, symbol }) {
 								{numberWithCommas(data.circulating_supply)}
 								{symbol}
 							</p>
-							<p>{remainSupply}%</p>
+							<p>{Math.round(remainSupply * 100) / 100}%</p>
 						</div>
-						<progress max={data.max_supply} value={data.circulating_supply} />
+						<progress className='progress-bar' max={data.max_supply} value={data.circulating_supply} />
 					</>
 				) : (
 					<div className='remaining-supply'>

--- a/src/css/COIN_STYLES.css
+++ b/src/css/COIN_STYLES.css
@@ -53,3 +53,7 @@ h3 {
 	font-weight: bold;
 	color: black;
 }
+
+.Coin-item > div {
+	font-weight: 450;
+}

--- a/src/css/PRICE_CHART_STYLES.css
+++ b/src/css/PRICE_CHART_STYLES.css
@@ -29,3 +29,14 @@
 .axis-left > .tick > text {
     fill: #585757;
 }
+
+.tooltip-info {
+    font-weight: bold;
+    font-size: 0.8rem;
+}
+
+.tooltip-box {
+    fill: rgba(82, 80, 80, 0.9);
+    z-index: 3;
+}
+    

--- a/src/css/SINGLE_BAR_STYLES.css
+++ b/src/css/SINGLE_BAR_STYLES.css
@@ -5,6 +5,7 @@
 	border-style: solid;
 	border-width: 0.1em 0 0.1em 0;
 	border-color: lightgrey;
+	height: 10em;
 }
 
 .single-bar-container > div > h6 {
@@ -17,6 +18,11 @@
 	flex-basis: 25%;
 	font-size: 0.9rem;
 	border-left: 0.1em solid lightgrey;
+}
+
+.single-bar-container > div > p {
+	font-size: 0.8rem;
+	font-weight: bold;;
 }
 
 .market-cap-container {
@@ -50,4 +56,21 @@ progress[value]::-webkit-progress-value {
 		rgba(0, 0, 0, 0.1) 66%,
 		transparent 66%
 	);
+}
+
+.green-text {
+	color: green !important;
+}
+
+.red-text {
+	color: rgb(212, 2, 2) !important;
+}
+
+.progress-bar {
+	width: 100%;
+	height: 5em;
+}
+
+.info-icon {
+	font-size: 1rem;
 }


### PR DESCRIPTION
This commit will introduce a simple chart to display the exact price and date for the price chart for every coin, this is activated on a MouseOn event.
Also, numbers have been added commas very three digits and given a little format.
Formatting functions have been passed onto another component file 